### PR TITLE
add missing parenthesis in raw python shell equivalent

### DIFF
--- a/justpath/oneliners.py
+++ b/justpath/oneliners.py
@@ -37,7 +37,7 @@ RAW = OneLiner(
     bash="echo $PATH",
     cmd="echo %PATH%",
     ps="echo $Env:PATH",
-    python="import os; print(os.environ['PATH']",
+    python="import os; print(os.environ['PATH'])",
 )
 
 BY_LINE = OneLiner(


### PR DESCRIPTION
Tried to print my raw path using the provided python shell equivalent and came across this typo.