### PR TITLE
Add Homebrew formula

### DIFF
--- a/Formula/justpath.rb
+++ b/Formula/justpath.rb
@@ -1,0 +1,68 @@
+class Justpath < Formula
+  include Language::Python::Virtualenv
+
+  desc "Explore PATH environment variable on Windows and Linux"
+  homepage "https://github.com/epogrebnyak/justpath"
+  url "https://files.pythonhosted.org/packages/b8/ac/5dfba6c01aeec43f96a513ce7a9797400b57b42b4444bb4dcb86350e50e7/justpath-0.0.18.tar.gz"
+  sha256 "ce506820d2eb1929c74d067f81fe501011d0a317a5a15283a13d8d7f9cf9bc08"
+  license "GPL-3.0-or-later"
+
+  depends_on "python@3.12"
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz"
+    sha256 "12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"
+  end
+
+  resource "colorama" do
+    url "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
+    sha256 "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"
+  end
+
+  resource "markdown-it-py" do
+    url "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz"
+    sha256 "cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3"
+  end
+
+  resource "mdurl" do
+    url "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz"
+    sha256 "bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+  end
+
+  resource "Pygments" do
+    url "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz"
+    sha256 "636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"
+  end
+
+  resource "rich" do
+    url "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz"
+    sha256 "73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4"
+  end
+
+  resource "shellingham" do
+    url "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz"
+    sha256 "8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+  end
+
+  resource "typer" do
+    url "https://files.pythonhosted.org/packages/73/f2/8214025e8fd1ada825d1b2183bd5895148b42b88ffe3ea3eed1224568ed0/typer-0.18.0.tar.gz"
+    sha256 "342049be1a608c972b0f77dd2b2573e74366b83465cfd5ebd3fede187e1f885e"
+  end
+
+  resource "typing-extensions" do
+    url "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz"
+    sha256 "0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # Test that the command runs and shows help
+    assert_match "Show directories from PATH", shell_output("#{bin}/justpath --help")
+
+    # Test that it can count paths (output will vary but should not error)
+    assert_match "directories in your PATH", shell_output("#{bin}/justpath --count")
+  end
+end

--- a/Formula/justpath.rb
+++ b/Formula/justpath.rb
@@ -1,7 +1,7 @@
 class Justpath < Formula
   include Language::Python::Virtualenv
 
-  desc "Explore PATH environment variable on Windows and Linux"
+  desc "Explore PATH environment variable on Windows, MacOS, and Linux"
   homepage "https://github.com/epogrebnyak/justpath"
   url "https://files.pythonhosted.org/packages/b8/ac/5dfba6c01aeec43f96a513ce7a9797400b57b42b4444bb4dcb86350e50e7/justpath-0.0.18.tar.gz"
   sha256 "ce506820d2eb1929c74d067f81fe501011d0a317a5a15283a13d8d7f9cf9bc08"

--- a/scripts/update_homebrew_formula.py
+++ b/scripts/update_homebrew_formula.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Update the Homebrew formula with the latest version and dependencies.
+
+This script:
+1. Creates a clean virtual environment
+2. Installs justpath and homebrew-pypi-poet
+3. Generates resource stanzas using poet
+4. Updates the Formula/justpath.rb file
+
+Usage:
+    python scripts/update_homebrew_formula.py
+
+To also install/test locally:
+    python scripts/update_homebrew_formula.py --test
+"""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def run_cmd(cmd: list[str], capture: bool = False) -> str | None:
+    """Run a command and optionally capture output."""
+    print(f"Running: {' '.join(cmd)}")
+    if capture:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        return result.stdout
+    subprocess.run(cmd, check=True)
+    return None
+
+
+def get_poet_output(venv_path: Path) -> str:
+    """Get full formula from poet."""
+    pip = venv_path / "bin" / "pip"
+    poet = venv_path / "bin" / "poet"
+
+    # Install justpath and poet
+    run_cmd([str(pip), "install", "justpath", "homebrew-pypi-poet"])
+
+    # Generate formula
+    output = run_cmd([str(poet), "-f", "justpath"], capture=True)
+    if output is None:
+        raise RuntimeError("poet failed to generate output")
+
+    return output
+
+
+def parse_poet_formula(poet_output: str) -> dict:
+    """Parse poet output and extract relevant parts."""
+    result = {}
+
+    # Extract URL
+    url_match = re.search(r'url "(https://files\.pythonhosted\.org/[^"]+)"', poet_output)
+    if url_match:
+        result["url"] = url_match.group(1)
+
+    # Extract sha256 (first occurrence is the main package)
+    sha_match = re.search(r'sha256 "([a-f0-9]+)"', poet_output)
+    if sha_match:
+        result["sha256"] = sha_match.group(1)
+
+    # Extract version from URL
+    version_match = re.search(r'justpath-([0-9.]+)\.tar\.gz', poet_output)
+    if version_match:
+        result["version"] = version_match.group(1)
+
+    # Extract all resource blocks
+    resources = []
+    resource_pattern = re.compile(
+        r'resource "([^"]+)" do\n\s+url "([^"]+)"\n\s+sha256 "([^"]+)"\n\s+end',
+        re.MULTILINE,
+    )
+    for match in resource_pattern.finditer(poet_output):
+        name, url, sha = match.groups()
+        # Skip types-colorama as it's only needed for type checking
+        if "types-colorama" not in name:
+            resources.append({"name": name, "url": url, "sha256": sha})
+
+    result["resources"] = resources
+    return result
+
+
+def generate_formula(parsed: dict) -> str:
+    """Generate the complete formula file."""
+    resources_str = "\n\n".join(
+        f'''  resource "{r['name']}" do
+    url "{r['url']}"
+    sha256 "{r['sha256']}"
+  end'''
+        for r in parsed["resources"]
+    )
+
+    formula = f'''class Justpath < Formula
+  include Language::Python::Virtualenv
+
+  desc "Explore PATH environment variable on Windows and Linux"
+  homepage "https://github.com/epogrebnyak/justpath"
+  url "{parsed['url']}"
+  sha256 "{parsed['sha256']}"
+  license "GPL-3.0-or-later"
+
+  depends_on "python@3.12"
+
+{resources_str}
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # Test that the command runs and shows help
+    assert_match "Show directories from PATH", shell_output("#{{bin}}/justpath --help")
+
+    # Test that it can count paths (output will vary but should not error)
+    assert_match "directories in your PATH", shell_output("#{{bin}}/justpath --count")
+  end
+end
+'''
+    return formula
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Update Homebrew formula")
+    parser.add_argument("--test", action="store_true", help="Run brew test after updating")
+    args = parser.parse_args()
+
+    # Find paths
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent
+    formula_path = repo_root / "Formula" / "justpath.rb"
+
+    # Create temp venv
+    with tempfile.TemporaryDirectory() as tmpdir:
+        venv_path = Path(tmpdir) / "venv"
+        run_cmd([sys.executable, "-m", "venv", str(venv_path)])
+
+        # Get poet output
+        poet_output = get_poet_output(venv_path)
+
+        # Parse and generate
+        parsed = parse_poet_formula(poet_output)
+        formula_content = generate_formula(parsed)
+
+        # Write formula
+        formula_path.write_text(formula_content)
+        print(f"Updated {formula_path}")
+        print(f"  Version: {parsed['version']}")
+        print(f"  SHA256: {parsed['sha256']}")
+        print(f"  Resources: {len(parsed['resources'])}")
+
+    if args.test:
+        print("\nRunning brew test...")
+        # Copy to tap if it exists
+        tap_formula = Path("/opt/homebrew/Library/Taps/eturino/homebrew-justpath/Formula/justpath.rb")
+        if tap_formula.parent.exists():
+            shutil.copy(formula_path, tap_formula)
+            run_cmd(["brew", "reinstall", "eturino/justpath/justpath", "--build-from-source"])
+            run_cmd(["brew", "test", "eturino/justpath/justpath"])
+        else:
+            print("Tap not found, skipping test")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add Homebrew formula (`Formula/justpath.rb`) that enables installation via Homebrew
- Add update script (`scripts/update_homebrew_formula.py`) to regenerate the formula when dependencies change

## Installation instructions for users

After merging, users can install justpath via:

```bash
brew tap epogrebnyak/justpath https://github.com/epogrebnyak/justpath
brew install justpath
```

Or in one command:
```bash
brew install epogrebnyak/justpath/justpath
```

## Formula maintenance

When dependencies change or a new version is released, regenerate the formula:

```bash
python scripts/update_homebrew_formula.py
```

This script:
1. Creates a clean virtual environment
2. Installs justpath and homebrew-pypi-poet
3. Generates the formula with all dependencies
4. Preserves custom settings (description, license, test block)

## Test plan

- [x] Verified formula installs correctly with `brew install --build-from-source`
- [x] Verified `brew test` passes
- [x] Verified `justpath --help` and `justpath --count` work after installation

Closes #14

---
Generated with [Claude Code](https://claude.com/claude-code)